### PR TITLE
Fix spiral/roadrunner-http#2.

### DIFF
--- a/src/PSR7Worker.php
+++ b/src/PSR7Worker.php
@@ -192,7 +192,7 @@ class PSR7Worker implements PSR7WorkerInterface
         }
 
         if ($httpRequest->parsed) {
-            return $request->withParsedBody($httpRequest->getParsedBody());
+            $request = $request->withParsedBody($httpRequest->getParsedBody());
         }
 
         if ($httpRequest->body) {


### PR DESCRIPTION
Fix https://github.com/spiral/roadrunner-http/issues/2. Keep request body when body parsed.