### PR TITLE
Fix the headers mapping

### DIFF
--- a/src/HttpWorker.php
+++ b/src/HttpWorker.php
@@ -124,9 +124,27 @@ class HttpWorker implements HttpWorkerInterface
         \parse_str($context['rawQuery'], $request->query);
 
         $request->attributes = (array)($context['attributes'] ?? []);
-        $request->headers = (array)($context['headers'] ?? []);
+        $request->headers = $this->filterHeaders((array)($context['headers'] ?? []));
         $request->cookies = (array)($context['cookies'] ?? []);
         $request->uploads = (array)($context['uploads'] ?? []);
         $request->parsed = (bool)$context['parsed'];
+    }
+
+    /**
+     * @param array<mixed, mixed> $headers
+     *
+     * @return array<string, mixed>
+     */
+    private function filterHeaders(array $headers): array
+    {
+        foreach ($headers as $key => $_) {
+            if (!\is_string($key) || $key === '') {
+                // ignore invalid header names or values (otherwise, the worker will be crashed)
+                // @see: <https://git.io/JzjgJ>
+                unset($headers[$key]);
+            }
+        }
+
+        return $headers;
     }
 }

--- a/src/PSR7Worker.php
+++ b/src/PSR7Worker.php
@@ -188,7 +188,12 @@ class PSR7Worker implements PSR7WorkerInterface
         }
 
         foreach ($httpRequest->headers as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            try {
+                $request = $request->withHeader($name, $value);
+            } catch (\InvalidArgumentException $e) {
+                // ignore invalid header names or values (otherwise, the worker will be crashed)
+                // @see: Nyholm/psr7 <https://git.io/JzjgJ>
+            }
         }
 
         if ($httpRequest->parsed) {

--- a/src/PSR7Worker.php
+++ b/src/PSR7Worker.php
@@ -188,12 +188,7 @@ class PSR7Worker implements PSR7WorkerInterface
         }
 
         foreach ($httpRequest->headers as $name => $value) {
-            try {
-                $request = $request->withHeader($name, $value);
-            } catch (\InvalidArgumentException $e) {
-                // ignore invalid header names or values (otherwise, the worker will be crashed)
-                // @see: Nyholm/psr7 <https://git.io/JzjgJ>
-            }
+            $request = $request->withHeader($name, $value);
         }
 
         if ($httpRequest->parsed) {


### PR DESCRIPTION
Hi @SerafimArts!

At this moment we have a potential DDoS vulnerability for all applications, that use the current package. This PR fixes one interesting (not) case.

### Details

The common worker code looks like this (as described in the readme file):

```php
while ($request = $psr7->waitRequest()) {
    try {
        // Reply by the 200 OK response
        $psr7->respond(new Response(200, [], 'Hello RoadRunner!'));
    } catch (\Throwable $e) {
        // Reply by the 500 Internal Server Error response
        $psr7->respond(new Response(500, [], 'Something Went Wrong!'));
        
        // Report error to RoadRunner (optional)
        $worker->error((string)$e);
    }
}
```

As you can see, if the exception occurs in the `$psr7->waitRequest()` method call - the worker will be crashed (developers trust the `waitRequest` method). Now, let's take a look at the following code ([Nyholm/psr7](https://github.com/Nyholm/psr7)):

https://github.com/Nyholm/psr7/blob/fafc2faf8d49b979f922fe416dc8805462dc1fe8/src/MessageTrait.php#L91-L95

```php
    public function withAddedHeader($header, $value): self
    {
        if (!\is_string($header) || '' === $header) {
            throw new \InvalidArgumentException('Header name must be an RFC 7230 compatible string.');
        }
    // ...
```

How to exploit this "feature"?

```bash
$ curl -H "0:foo" "https://roadrunner.dev"      
worker error: EOF%
```

The worker has been crashed and restarted and restarted by the `rr` daemon. This is a very expensive operation, and if we run something like:

```bash
$ while true; do curl -H "0:foo" "https://roadrunner.dev"; done
```

In 10..15 threads - after a few seconds host will be down. After this PR merging and releasing the fixed version - "wrong" headers will be simply ignored.