### PR TITLE
Add support for raw body

### DIFF
--- a/src/HttpWorker.php
+++ b/src/HttpWorker.php
@@ -157,6 +157,8 @@ class HttpWorker implements HttpWorkerInterface
         $request->cookies = (array)($context['cookies'] ?? []);
         $request->uploads = (array)($context['uploads'] ?? []);
         $request->parsed = (bool)$context['parsed'];
+
+        $request->attributes[Request::PARSED_BODY_ATTRIBUTE_NAME] = $request->parsed;
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -33,6 +33,8 @@ use JetBrains\PhpStorm\Immutable;
 #[Immutable]
 final class Request
 {
+    public const PARSED_BODY_ATTRIBUTE_NAME = 'rr_parsed_body';
+
     /**
      * @var string
      */


### PR DESCRIPTION
Add support for raw_body config implemented at https://github.com/roadrunner-server/http/pull/45

I did not identify any BC making parse of the raw body when it is not empty. Do you see any?