### PR TITLE
Throw StreamStopException when stream is stopped instead of just RuntimeException

### DIFF
--- a/src/Exception/StreamStoppedException.php
+++ b/src/Exception/StreamStoppedException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Http\Exception;
+
+final class StreamStoppedException extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Stream has been stopped by the client.');
+    }
+}

--- a/src/HttpWorker.php
+++ b/src/HttpWorker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\RoadRunner\Http;
 
 use Generator;
+use Spiral\RoadRunner\Http\Exception\StreamStoppedException;
 use Spiral\RoadRunner\Message\Command\StreamStop;
 use Spiral\RoadRunner\Payload;
 use Spiral\RoadRunner\WorkerInterface;
@@ -93,7 +94,7 @@ class HttpWorker implements HttpWorkerInterface
             }
             $content = (string)$body->current();
             if ($this->worker->getPayload(StreamStop::class) !== null) {
-                $body->throw(new \RuntimeException('Stream has been stopped by the client.'));
+                $body->throw(new StreamStoppedException());
                 return;
             }
             $this->worker->respond(new Payload($content, $head, false));

--- a/tests/Feature/StreamResponseTest.php
+++ b/tests/Feature/StreamResponseTest.php
@@ -6,6 +6,7 @@ namespace Spiral\RoadRunner\Tests\Http\Feature;
 
 use PHPUnit\Framework\TestCase;
 use Spiral\Goridge\SocketRelay;
+use Spiral\RoadRunner\Http\Exception\StreamStoppedException;
 use Spiral\RoadRunner\Http\HttpWorker;
 use Spiral\RoadRunner\Payload;
 use Spiral\RoadRunner\Tests\Http\Server\Command\BaseCommand;
@@ -80,7 +81,7 @@ class StreamResponseTest extends TestCase
                 $this->sendCommand(new StreamStop());
                 try {
                     yield ' Wo';
-                } catch (\Throwable $e) {
+                } catch (StreamStoppedException $e) {
                     return;
                 }
                 yield 'rld';


### PR DESCRIPTION
…imeException

| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  | ✔️ <!-- please update "Other Features" section in CHANGELOG.md file -->

Throw StreamStopException when stream is stopped instead of just RuntimeException