### PR TITLE
Allow symfony/process 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,7 @@
         "jetbrains/phpstorm-attributes": "^1.0",
         "nyholm/psr7": "^1.3",
         "phpunit/phpunit": "^10.0",
-        "symfony/process": "^6.2",
-        "symfony/var-dumper": "^6.3",
+        "symfony/process": "^6.2 || ^7.0",
         "vimeo/psalm": "^5.9"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ❌ 
| Issues        | https://github.com/roadrunner-php/issues/issues/27

And the unused dev dependency **symfony/var-dumper** has been removed.