### PR TITLE
Remove PHP versions from GitHub Actions, fix the documentation link

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,7 +2,6 @@ on:
   pull_request: null
   push:
     branches:
-      - master
       - '*.*'
 
 name: phpunit
@@ -13,7 +12,5 @@ jobs:
     with:
       os: >-
         ['ubuntu-latest']
-      php: >-
-        ['8.1', '8.2']
       stability: >-
         ['prefer-lowest', 'prefer-stable']

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -2,7 +2,6 @@ on:
   pull_request: null
   push:
     branches:
-      - master
       - '*.*'
 
 name: static analysis
@@ -13,5 +12,3 @@ jobs:
     with:
       os: >-
         ['ubuntu-latest']
-      php: >-
-        ['8.1']

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ with much greater performance and flexibility.
 
 <p align="center">
 	<a href="https://roadrunner.dev/"><b>Official Website</b></a> | 
-	<a href="https://roadrunner.dev/docs"><b>Documentation</b></a>
+	<a href="https://docs.roadrunner.dev"><b>Documentation</b></a>
 </p>
 
 Repository:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "homepage": "https://spiral.dev/",
     "support": {
-        "docs": "https://roadrunner.dev/docs",
+        "docs": "https://docs.roadrunner.dev",
         "issues": "https://github.com/roadrunner-server/roadrunner/issues",
         "forum": "https://forum.roadrunner.dev/",
         "chat": "https://discord.gg/V6EK4he"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌
| New feature?  | ❌

1. Fixed the link to the documentation. 
2. PHP versions have been removed from GitHub Actions (versions 8.1-8.3 specified here: https://github.com/spiral/gh-actions/blob/master/.github/workflows/phpunit.yml#L32, https://github.com/spiral/gh-actions/blob/master/.github/workflows/psalm.yml#L12 will be used).
