### PR TITLE
Fixed signature HttpWorkerInterface

### DIFF
--- a/src/HttpWorkerInterface.php
+++ b/src/HttpWorkerInterface.php
@@ -30,5 +30,5 @@ interface HttpWorkerInterface extends WorkerAwareInterface
      *        message's headers. Each key MUST be a header name, and each value MUST be an array of strings for
      *        that header.
      */
-    public function respond(int $status, string|Generator $body, array $headers = []): void;
+    public function respond(int $status, string|Generator $body, array $headers = [],  bool $endOfStream = true): void;
 }

--- a/src/HttpWorkerInterface.php
+++ b/src/HttpWorkerInterface.php
@@ -6,7 +6,6 @@ namespace Spiral\RoadRunner\Http;
 
 use Generator;
 use Spiral\RoadRunner\WorkerAwareInterface;
-use Stringable;
 
 /**
  * @psalm-import-type HeadersList from Request
@@ -22,7 +21,7 @@ interface HttpWorkerInterface extends WorkerAwareInterface
      * Send response to the application server.
      *
      * @param int $status Http status code
-     * @param Generator<mixed, scalar|Stringable, mixed, Stringable|scalar|null>|string $body Body of response.
+     * @param \Generator<mixed, scalar|\Stringable, mixed, \Stringable|scalar|null>|string $body Body of response.
      *        If the body is a generator, then each yielded value will be sent as a separated stream chunk.
      *        Returned value will be sent as a last stream package.
      *        Note: Stream response is supported by RoadRunner since version 2023.3
@@ -30,5 +29,5 @@ interface HttpWorkerInterface extends WorkerAwareInterface
      *        message's headers. Each key MUST be a header name, and each value MUST be an array of strings for
      *        that header.
      */
-    public function respond(int $status, string|Generator $body, array $headers = [],  bool $endOfStream = true): void;
+    public function respond(int $status, string|\Generator $body, array $headers = [], bool $endOfStream = true): void;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    |❌ <!-- please update "xxx Impact Changes" section in CHANGELOG.md file -->
| New feature?  |❌ <!-- please update "Other Features" section in CHANGELOG.md file -->

Fixed signature HttpWorkerInterface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional flag to response handling that explicitly marks the end of streaming responses. This enables finer control over when streams terminate and supports more robust streaming scenarios. Existing behavior remains unchanged if the flag isn’t provided, ensuring backward compatibility and a seamless upgrade path for current integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->