### PR TITLE
fix(worker): correct JSON autodetection for payload body

### DIFF
--- a/src/HttpWorker.php
+++ b/src/HttpWorker.php
@@ -64,7 +64,7 @@ class HttpWorker implements HttpWorkerInterface
         }
 
         if (static::$codec === null) {
-            static::$codec = \json_validate($payload->header) ? Frame::CODEC_JSON : Frame::CODEC_PROTO;
+            static::$codec = \json_validate($payload->body) ? Frame::CODEC_JSON : Frame::CODEC_PROTO;
         }
 
         if (static::$codec === Frame::CODEC_PROTO) {


### PR DESCRIPTION
Change wrong detect codec from header.
Change header to body.

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
| Issues        | Disabled
| Docs PR       | Disabled

### fix(worker): correct JSON autodetection for payload body

Previously, the codec detection incorrectly validated the **header** instead of the **body**, causing JSON payloads to be misidentified.
This fix updates the autodetection logic to check the payload **body** when determining whether to use `CODEC_JSON` or `CODEC_PROTO`.

#### Before

```php
static::$codec = \json_validate($payload->header)
    ? Frame::CODEC_JSON
    : Frame::CODEC_PROTO;
```

#### After

```php
static::$codec = \json_validate($payload->body)
    ? Frame::CODEC_JSON
    : Frame::CODEC_PROTO;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request codec detection to properly handle JSON and Protobuf payloads by validating request body content, ensuring more accurate and reliable request processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->