### PR TITLE
EndOfStreamAwareHttpWorkerInterface

### DIFF
--- a/src/EndOfStreamAwareHttpWorkerInterface.php
+++ b/src/EndOfStreamAwareHttpWorkerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Http;
+
+/**
+ * @psalm-import-type HeadersList from Request
+ */
+interface EndOfStreamAwareHttpWorkerInterface extends HttpWorkerInterface
+{
+    /**
+     * Send response to the application server.
+     *
+     * @param int $status Http status code
+     * @param \Generator<mixed, scalar|\Stringable, mixed, \Stringable|scalar|null>|string $body Body of response.
+     *        If the body is a generator, then each yielded value will be sent as a separated stream chunk.
+     *        Returned value will be sent as a last stream package.
+     *        Note: Stream response is supported by RoadRunner since version 2023.3
+     * @param HeadersList|array<array-key, array<array-key, string>> $headers $headers An associative array of the
+     *        message's headers. Each key MUST be a header name, and each value MUST be an array of strings for
+     *        that header.
+     */
+    public function respond(int $status, string|\Generator $body = '', array $headers = [], bool $endOfStream = true): void;
+}

--- a/src/HttpWorker.php
+++ b/src/HttpWorker.php
@@ -38,7 +38,7 @@ use Spiral\RoadRunner\WorkerInterface;
  *
  * @api
  */
-class HttpWorker implements HttpWorkerInterface
+class HttpWorker implements HttpWorkerInterface, EndOfStreamAwareHttpWorkerInterface
 {
     private static ?int $codec = null;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    |❌
| New feature?  |❌

Alternative solution of #30.

Instead of rewriting the `HttpWorkerInterface`, I created `EndOfStreamAwareHttpWorkerInterface`, which overrides the respond method and adds an optional `bool` `$endOfStream` argument.

The `HttpWorker` class now implements `EndOfStreamAwareHttpWorkerInterface`.

This change doesn't break BC.

In the future, the `$endOfStream` argument can be added to the main `HttpWorkerInterface`, and `EndOfStreamAwareHttpWorkerInterface` can be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented end-of-stream aware HTTP response handling to enable more reliable streaming content delivery with explicit response completion signaling and better termination management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->