### PR TITLE
Add `$endOfStream` param to `HttpWorkerInterface::respond()`, remove deprecations

### DIFF
--- a/src/HttpWorkerInterface.php
+++ b/src/HttpWorkerInterface.php
@@ -28,6 +28,8 @@ interface HttpWorkerInterface extends WorkerAwareInterface
      * @param HeadersList|array<array-key, array<array-key, string>> $headers $headers An associative array of the
      *        message's headers. Each key MUST be a header name, and each value MUST be an array of strings for
      *        that header.
+     * @param bool $endOfStream End of stream.
+     *        The {@see true} value means the Payload block is last in the stream.
      */
-    public function respond(int $status, string|\Generator $body, array $headers = []): void;
+    public function respond(int $status, string|\Generator $body, array $headers = [], bool $endOfStream = true): void;
 }

--- a/src/PSR7Worker.php
+++ b/src/PSR7Worker.php
@@ -57,8 +57,6 @@ class PSR7Worker implements PSR7WorkerInterface
     }
 
     /**
-     * @psalm-suppress DeprecatedMethod
-     *
      * @param bool $populateServer Whether to populate $_SERVER superglobal.
      *
      * @throws \JsonException
@@ -104,22 +102,6 @@ class PSR7Worker implements PSR7WorkerInterface
     protected function configureServer(Request $request): array
     {
         return GlobalState::enrichServerVars($request);
-    }
-
-    /**
-     * @deprecated
-     */
-    protected function timeInt(): int
-    {
-        return \time();
-    }
-
-    /**
-     * @deprecated
-     */
-    protected function timeFloat(): float
-    {
-        return \microtime(true);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ✔️
| New feature?  |❌ <!-- please update "Other Features" section in CHANGELOG.md file -->

Prepare v4 release:

- Remove deprecated methods.
- Bump PHP version to >=8.2
- Fix signature of `HttpWoprkerInterface` - add `$endOfStream` argument.
