### PR TITLE
Expose `HTTP_HOST` in `GlobalState::enrichServerVars()`

### DIFF
--- a/src/GlobalState.php
+++ b/src/GlobalState.php
@@ -35,7 +35,7 @@ final class GlobalState
         $server['REQUEST_METHOD'] = $request->method;
         $server['HTTP_USER_AGENT'] = '';
 
-        $parts = \parse_url($uri);
+        $parts = \parse_url($request->uri);
 
         if (isset($parts['host'])) {
             $server['HTTP_HOST'] = isset($parts['port'])

--- a/src/GlobalState.php
+++ b/src/GlobalState.php
@@ -35,17 +35,13 @@ final class GlobalState
         $server['REQUEST_METHOD'] = $request->method;
         $server['HTTP_USER_AGENT'] = '';
 
-        $host = parse_url($request->uri, PHP_URL_HOST);
-        $port = parse_url($request->uri, PHP_URL_PORT);
+        $parts = \parse_url($uri);
 
-        if ($host != null) {
-            $server['HTTP_HOST'] = $host;
+        if (isset($parts['host'])) {
+            $server['HTTP_HOST'] = isset($parts['port'])
+                ? $parts['host'] . ':' . $parts['port'] 
+                : $parts['host'];
         }
-
-        if ($host != null && $port != null) {
-            $server['HTTP_HOST'] = $host . ':' . $port;
-        }
-
         foreach ($request->headers as $key => $value) {
             $key = \strtoupper(\str_replace('-', '_', $key));
 

--- a/src/GlobalState.php
+++ b/src/GlobalState.php
@@ -39,7 +39,7 @@ final class GlobalState
 
         if (isset($parts['host'])) {
             $server['HTTP_HOST'] = isset($parts['port'])
-                ? $parts['host'] . ':' . $parts['port'] 
+                ? $parts['host'] . ':' . $parts['port']
                 : $parts['host'];
         }
         foreach ($request->headers as $key => $value) {

--- a/src/GlobalState.php
+++ b/src/GlobalState.php
@@ -35,6 +35,17 @@ final class GlobalState
         $server['REQUEST_METHOD'] = $request->method;
         $server['HTTP_USER_AGENT'] = '';
 
+        $host = parse_url($request->uri, PHP_URL_HOST);
+        $port = parse_url($request->uri, PHP_URL_PORT);
+
+        if ($host != null) {
+            $server['HTTP_HOST'] = $host;
+        }
+
+        if ($host != null && $port != null) {
+            $server['HTTP_HOST'] = $host . ':' . $port;
+        }
+
         foreach ($request->headers as $key => $value) {
             $key = \strtoupper(\str_replace('-', '_', $key));
 

--- a/tests/Unit/GlobalStateTest.php
+++ b/tests/Unit/GlobalStateTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Tests\Http\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Spiral\RoadRunner\Http\GlobalState;
+use Spiral\RoadRunner\Http\Request;
+
+final class GlobalStateTest extends TestCase
+{
+    /**
+     * @return iterable<array{0: Request, 1: array<array-key, mixed>}>
+     */
+    public static function enrichServerVarsDataProvider(): iterable
+    {
+        yield [
+            new Request(),
+            [
+                'REQUEST_URI'        => 'http://localhost',
+                'REMOTE_ADDR'        => '127.0.0.1',
+                'REQUEST_METHOD'     => 'GET',
+                'HTTP_USER_AGENT'    => '',
+                'HTTP_HOST'          => 'localhost',
+            ],
+        ];
+
+        yield [
+            new Request(uri: 'https://roadrunner.dev'),
+            [
+                'REQUEST_URI'        => 'https://roadrunner.dev',
+                'REMOTE_ADDR'        => '127.0.0.1',
+                'REQUEST_METHOD'     => 'GET',
+                'HTTP_USER_AGENT'    => '',
+                'HTTP_HOST'          => 'roadrunner.dev',
+            ],
+        ];
+
+        yield [
+            new Request(uri: 'https://roadrunner.dev:8080'),
+            [
+                'REQUEST_URI'        => 'https://roadrunner.dev:8080',
+                'REMOTE_ADDR'        => '127.0.0.1',
+                'REQUEST_METHOD'     => 'GET',
+                'HTTP_USER_AGENT'    => '',
+                'HTTP_HOST'          => 'roadrunner.dev:8080',
+            ],
+        ];
+    }
+
+    /**
+     * @param array<array-key, mixed> $expected
+     */
+    #[DataProvider('enrichServerVarsDataProvider')]
+    public function testEnrichServerVars(Request $request, array $expected): void
+    {
+        $_SERVER = [];
+
+        $server = GlobalState::enrichServerVars($request);
+
+        $this->assertArrayHasKey('REQUEST_TIME', $server);
+        $this->assertArrayHasKey('REQUEST_TIME_FLOAT', $server);
+
+        unset($server['REQUEST_TIME']);
+        unset($server['REQUEST_TIME_FLOAT']);
+
+        $this->assertEquals($server, $expected);
+    }
+}

--- a/tests/Unit/PSR7WorkerTest.php
+++ b/tests/Unit/PSR7WorkerTest.php
@@ -44,6 +44,7 @@ final class PSR7WorkerTest extends TestCase
                     'HTTP_USER_AGENT' => '',
                     'CONTENT_TYPE' => 'application/html',
                     'HTTP_CONNECTION' => 'keep-alive',
+                    'HTTP_HOST' =>   'localhost',
                 ],
             ],
             [
@@ -56,6 +57,7 @@ final class PSR7WorkerTest extends TestCase
                     'REQUEST_METHOD' => 'GET',
                     'HTTP_USER_AGENT' => '',
                     'CONTENT_TYPE' => 'application/json',
+                    'HTTP_HOST' =>   'localhost',
                 ],
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ✔️
| Issues        | #... <!-- prefix each issue number with "#" symbol, no need to create an issue if none exist, explain below instead -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request handling now derives the HTTP Host (including port when present) from incoming request URIs so server context is accurate.

* **Tests**
  * Updated fixtures to expect the HTTP Host header in server-state validations.
  * Added unit tests covering enrichment of server variables for URIs with/without host and port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->