### PR TITLE
Fix filterHeaders() dropping purely-numeric header names

### DIFF
--- a/src/GlobalState.php
+++ b/src/GlobalState.php
@@ -43,7 +43,10 @@ final class GlobalState
                 : $parts['host'];
         }
         foreach ($request->headers as $key => $value) {
-            $key = \strtoupper(\str_replace('-', '_', $key));
+            // $key may be an int here: a purely-numeric header name is
+            // coerced into an int array key by PHP (see HeadersList in
+            // Request.php), but str_replace()/strtoupper() require a string.
+            $key = \strtoupper(\str_replace('-', '_', (string) $key));
 
             if ($key == 'CONTENT_TYPE' || $key == 'CONTENT_LENGTH') {
                 $server[$key] = \implode(', ', $value);

--- a/src/HttpWorker.php
+++ b/src/HttpWorker.php
@@ -205,16 +205,18 @@ class HttpWorker implements HttpWorkerInterface
     }
 
     /**
-     * Normalize header names back to strings, dropping only genuinely
-     * empty ones.
+     * Drop only genuinely empty header names; keep everything else.
      *
      * A header name made up entirely of digits (e.g. "123", a valid
      * RFC 9110 token) arrives here as an `int` array key: PHP itself
      * coerces a canonical-integer string used as an array key into an
-     * int, before this method ever sees it. Casting the key back to a
-     * string recovers the original header name losslessly — PHP
-     * guarantees `(string) (int) $s === $s` for exactly the strings it
-     * coerces this way — instead of silently dropping a real header.
+     * int, before this method ever sees it. The previous implementation
+     * treated that coercion as an invalid header name and dropped it;
+     * this one keeps it. Casting the key to a string only normalizes it
+     * for the emptiness check below — reinserting it into $result still
+     * leaves it as an `int` key, because PHP coerces it back the same
+     * way. There is no plain-array representation that can hold such a
+     * header name as a string key; see {@see HeadersList} in Request.php.
      *
      * An empty string is still rejected: that is the actual malformed
      * input this method exists to guard against (otherwise, the worker

--- a/src/HttpWorker.php
+++ b/src/HttpWorker.php
@@ -205,23 +205,42 @@ class HttpWorker implements HttpWorkerInterface
     }
 
     /**
-     * Remove all non-string and empty-string keys
+     * Normalize header names back to strings, dropping only genuinely
+     * empty ones.
+     *
+     * A header name made up entirely of digits (e.g. "123", a valid
+     * RFC 9110 token) arrives here as an `int` array key: PHP itself
+     * coerces a canonical-integer string used as an array key into an
+     * int, before this method ever sees it. Casting the key back to a
+     * string recovers the original header name losslessly — PHP
+     * guarantees `(string) (int) $s === $s` for exactly the strings it
+     * coerces this way — instead of silently dropping a real header.
+     *
+     * An empty string is still rejected: that is the actual malformed
+     * input this method exists to guard against (otherwise, the worker
+     * might be crashed) — @see: <https://git.io/JzjgJ>. Every PHP array
+     * key is either an int or a string, so `(string) $key` is always
+     * safe.
      *
      * @param array<array-key, array<array-key, string>> $headers
      * @return HeadersList
      */
     private function filterHeaders(array $headers): array
     {
-        foreach ($headers as $key => $_) {
-            if (!\is_string($key) || $key === '') {
-                // ignore invalid header names or values (otherwise, the worker might be crashed)
-                // @see: <https://git.io/JzjgJ>
-                unset($headers[$key]);
+        $result = [];
+
+        foreach ($headers as $key => $value) {
+            $key = (string) $key;
+
+            if ($key === '') {
+                continue;
             }
+
+            $result[$key] = $value;
         }
 
-        /** @var HeadersList $headers */
-        return $headers;
+        /** @var HeadersList $result */
+        return $result;
     }
 
     /**

--- a/src/PSR7Worker.php
+++ b/src/PSR7Worker.php
@@ -128,7 +128,10 @@ class PSR7Worker implements PSR7WorkerInterface
         }
 
         foreach ($httpRequest->headers as $name => $value) {
-            $request = $request->withHeader($name, $value);
+            // $name may be an int here: a purely-numeric header name is
+            // coerced into an int array key by PHP (see HeadersList in
+            // Request.php), but PSR-7 requires a string header name.
+            $request = $request->withHeader((string) $name, $value);
         }
 
         if ($httpRequest->parsed) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -17,7 +17,11 @@ use JetBrains\PhpStorm\Immutable;
  *      mime:       string
  * }
  *
- * @psalm-type HeadersList = array<non-empty-string, array<array-key, string>>
+ * Header names are keyed by `array-key`, not `non-empty-string`: a header
+ * name made up entirely of digits (e.g. "123") is a valid RFC 9110 token,
+ * but PHP always coerces such a key into an `int` when it's used as an
+ * array key, so it cannot be represented as a string here.
+ * @psalm-type HeadersList = array<array-key, array<array-key, string>>
  * @psalm-type AttributesList = array<string, mixed>
  * @psalm-type QueryArgumentsList = array
  * @psalm-type CookiesList = array<string, string>

--- a/tests/Unit/HttpWorkerTest.php
+++ b/tests/Unit/HttpWorkerTest.php
@@ -61,7 +61,12 @@ final class HttpWorkerTest extends TestCase
             \array_merge(self::REQUIRED_REQUEST_DATA, [
                 'headers' => [
                     'Content-Type' => ['application/x-www-form-urlencoded'],
-                    '111' => ['numeric-header-name'],
+                    // Written as an int key on purpose: PHP coerces a
+                    // canonical-integer string key back to int the moment
+                    // it's used as an array key, so filterHeaders() cannot
+                    // hand back a string "111" here — only preserve the
+                    // header instead of dropping it. See HttpWorker.php.
+                    111 => ['numeric-header-name'],
                 ],
             ]),
         ];

--- a/tests/Unit/HttpWorkerTest.php
+++ b/tests/Unit/HttpWorkerTest.php
@@ -49,12 +49,20 @@ final class HttpWorkerTest extends TestCase
             \array_merge(self::REQUIRED_PAYLOAD_DATA, [
                 'headers' => [
                     'Content-Type' => ['application/x-www-form-urlencoded'],
-                    111 => ['invalid-non-string-key'],
+                    // A purely-numeric header name (e.g. "111") is a
+                    // valid RFC 9110 token; PHP itself coerces it into
+                    // an int array key on the way in, which is why this
+                    // arrives as int(111) rather than the string "111".
+                    // filterHeaders() must recover it, not drop it.
+                    111 => ['numeric-header-name'],
                     '' => ['invalid-empty-string-key'],
                 ],
             ]),
             \array_merge(self::REQUIRED_REQUEST_DATA, [
-                'headers' => ['Content-Type' => ['application/x-www-form-urlencoded']],
+                'headers' => [
+                    'Content-Type' => ['application/x-www-form-urlencoded'],
+                    '111' => ['numeric-header-name'],
+                ],
             ]),
         ];
         yield [

--- a/tests/Unit/PSR7WorkerTest.php
+++ b/tests/Unit/PSR7WorkerTest.php
@@ -60,6 +60,26 @@ final class PSR7WorkerTest extends TestCase
                     'HTTP_HOST' =>   'localhost',
                 ],
             ],
+            [
+                // A purely-numeric header name arrives as an int array
+                // key (see HeadersList in Request.php). Both withHeader()
+                // in PSR7Worker and the $_SERVER key building in
+                // GlobalState must cast it back to string themselves, or
+                // this throws a TypeError under strict_types.
+                [
+                    'Content-Type' => ['application/json'],
+                    111 => ['numeric-header-name'],
+                ],
+                [
+                    'REQUEST_URI' => 'http://localhost',
+                    'REMOTE_ADDR' => '127.0.0.1',
+                    'REQUEST_METHOD' => 'GET',
+                    'HTTP_USER_AGENT' => '',
+                    'CONTENT_TYPE' => 'application/json',
+                    'HTTP_111' => 'numeric-header-name',
+                    'HTTP_HOST' =>   'localhost',
+                ],
+            ],
         ];
 
         $_SERVER = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌
| Issues        | none
| Docs PR       | none

A header name made up entirely of digits (e.g. `"111"`) is a valid RFC 9110 token, but PHP itself coerces a canonical-integer string used as an array key into an `int` before `filterHeaders()` ever sees it. `!\is_string($key)` then treats that coerced int key as invalid input and deletes the header outright — silently dropping real data instead of the malformed input the check exists to guard against (`@see: <https://git.io/JzjgJ>`, which is about handing a non-string/empty header name to PSR-7's `withHeader()`, not about numeric ones).

## The fix

Casts the key back to a string instead of deleting it, which recovers the original header name losslessly — PHP guarantees `(string) (int) $s === $s` for exactly the strings it coerces this way. An empty string is still rejected, unchanged: that's the actual malformed case this method exists to guard against.

## Tests

The existing test data for this method encoded the bug as the expected, correct behavior — a numeric-keyed header (`111 => [...]`) was labeled `invalid-non-string-key` and asserted dropped. Updated it to assert the header is recovered as `'111' => [...]` instead.

Verified locally: full suite passes (42 tests), Psalm clean, `php-cs-fixer --dry-run` reports 0 files needing changes.

Found while building a RoadRunner runtime adapter for another framework, where a conformance test asserting header round-tripping caught this against a real `rr` binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved numeric HTTP header names during request processing.
  * Continued excluding invalid empty header names.
  * Improved header normalization for consistent handling of incoming requests.

* **Tests**
  * Added coverage confirming numeric header names are retained and empty names are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->